### PR TITLE
fix: repair malformed translation placeholders before sprintf runs

### DIFF
--- a/complianz-terms-conditions.php
+++ b/complianz-terms-conditions.php
@@ -321,6 +321,11 @@ if ( ! class_exists( 'COMPLIANZ_TC' ) ) {
 					load_plugin_textdomain( 'complianz-terms-conditions' );
 				}
 			);
+
+			// Community translations sometimes damage printf placeholders, which makes
+			// sprintf() fatal on PHP 8; repair them before any caller formats them.
+			add_filter( 'gettext', 'cmplz_tc_repair_translation', 10, 3 );
+			add_filter( 'gettext_with_context', 'cmplz_tc_repair_translation_with_context', 10, 4 );
 		}
 	}
 

--- a/functions.php
+++ b/functions.php
@@ -19,7 +19,65 @@
 
 defined( 'ABSPATH' ) || die( 'you do not have acces to this page!' );
 
+if ( ! function_exists( 'cmplz_tc_repair_placeholders' ) ) {
+	/**
+	 * Restores printf placeholders that a translation dropped the conversion character from.
+	 *
+	 * Community translations can damage positional placeholders (ex.: the cs_CZ
+	 * strings turned `%4$s` into `%4$` and `%1$sprivacy` into `%1$privacy`). To avoid
+	 * a fatal PHP 8 ValueError from taking down every request on affected sites, rewriting
+	 * `%N$` to `%N$s` keeps the sentence and its links intact.
+	 *
+	 * @since  1.4.1
+	 *
+	 * @param  string $translation Translated string, possibly with damaged placeholders.
+	 * @return string              The string with every positional placeholder valid again.
+	 */
+	function cmplz_tc_repair_placeholders( $translation ) {
+		// Every damaged placeholder contains `$`, so strings without one need no work.
+		if ( false === strpos( $translation, '$' ) ) {
+			return $translation;
+		}
 
+		// Matches `%N$` only when what follows cannot complete a conversion specification.
+		// A translated word starting with a conversion character (`%1$binary`) still reads
+		// as valid and is left alone: it prints oddly, but sprintf() no longer fatals.
+		return preg_replace( "/%(\d+)\\\$(?![-+0']*(?:'.)?-?\d*(?:\.\d+)?[bcdeEfFgGosuxX])/", '%${1}$s', $translation );
+	}
+}
+
+if ( ! function_exists( 'cmplz_tc_repair_translation' ) ) {
+	/**
+	 * Repairs placeholders in this plugin's translations. Filters `gettext`.
+	 *
+	 * @since  1.4.1
+	 *
+	 * @param  string $translation Translated text.
+	 * @param  string $text        Original, untranslated text.
+	 * @param  string $domain      Text domain the string belongs to.
+	 * @return string              Translated text with valid placeholders.
+	 */
+	function cmplz_tc_repair_translation( $translation, $text, $domain ) {
+		return 'complianz-terms-conditions' === $domain ? cmplz_tc_repair_placeholders( $translation ) : $translation;
+	}
+}
+
+if ( ! function_exists( 'cmplz_tc_repair_translation_with_context' ) ) {
+	/**
+	 * Repairs placeholders in this plugin's contextual translations. Filters `gettext_with_context`.
+	 *
+	 * @since  1.4.1
+	 *
+	 * @param  string $translation Translated text.
+	 * @param  string $text        Original, untranslated text.
+	 * @param  string $context     Context the string was registered with.
+	 * @param  string $domain      Text domain the string belongs to.
+	 * @return string              Translated text with valid placeholders.
+	 */
+	function cmplz_tc_repair_translation_with_context( $translation, $text, $context, $domain ) {
+		return 'complianz-terms-conditions' === $domain ? cmplz_tc_repair_placeholders( $translation ) : $translation;
+	}
+}
 
 if ( ! function_exists( 'cmplz_tc_get_template' ) ) {
 	/**

--- a/tests/test-format-guard.php
+++ b/tests/test-format-guard.php
@@ -1,0 +1,171 @@
+<?php
+/**
+ * Tests for the placeholder repair applied to this plugin's translations.
+ *
+ * @package Complianz_Terms_Conditions
+ */
+
+/**
+ * Covers cmplz_tc_repair_placeholders() and the gettext filters that apply it.
+ *
+ * The malformed strings below are the real cs_CZ translations that crashed the
+ * plugin on PHP 8 (Asana 1214573807894849), where `%N$s` lost its `s`.
+ */
+class FormatGuardTest extends WP_UnitTestCase {
+
+	/**
+	 * Injects a replacement translation for one original string.
+	 *
+	 * Runs at priority 5 so the plugin's repair filter, registered at 10, sees it.
+	 *
+	 * @param  string $needle      Fragment identifying the original string.
+	 * @param  string $translation Translation to serve instead.
+	 * @param  string $filter      Either 'gettext' or 'gettext_with_context'.
+	 * @return callable            The registered callback, for remove_filter().
+	 */
+	private function fake_translation( $needle, $translation, $filter = 'gettext' ) {
+		$args     = 'gettext' === $filter ? 3 : 4;
+		$callback = static function ( $current, $text ) use ( $needle, $translation ) {
+			return false !== strpos( $text, $needle ) ? $translation : $current;
+		};
+
+		add_filter( $filter, $callback, 5, $args );
+
+		return $callback;
+	}
+
+	/**
+	 * Every damaged cs_CZ placeholder is made valid again.
+	 *
+	 * @return void
+	 */
+	public function test_reported_czech_strings_are_repaired() {
+		$cases = array(
+			// config/steps.php:72 — the crash in the report.
+			' Upozorňujeme, v naší %1$sdocumentaci%2$s. Zašlete nám prosím %3$sžádost o podporu%4$.'
+				=> ' Upozorňujeme, v naší %1$sdocumentaci%2$s. Zašlete nám prosím %3$sžádost o podporu%4$s.',
+			// config/documents/terms-conditions.php:612.
+			'stránky %1$scontact%2$.'              => 'stránky %1$scontact%2$s.',
+			// config/documents/terms-conditions.php:561 — every placeholder damaged.
+			'podmínky %1$prohlášením%2$ a %3$zásadami%4$ mezi vámi a %5$ ohledně.'
+				=> 'podmínky %1$sprohlášením%2$s a %3$szásadami%4$s mezi vámi a %5$s ohledně.',
+			// config/documents/terms-conditions.php:437.
+			'v našich %3$sZásadách%4$.'            => 'v našich %3$sZásadách%4$s.',
+			// class-document.php:1861.
+			'nebo nejprve %1$vytvořte nabídku%2$.' => 'nebo nejprve %1$svytvořte nabídku%2$s.',
+		);
+
+		foreach ( $cases as $damaged => $expected ) {
+			$this->assertSame( $expected, cmplz_tc_repair_placeholders( $damaged ) );
+		}
+	}
+
+	/**
+	 * Valid patterns and plain text are returned untouched.
+	 *
+	 * @return void
+	 */
+	public function test_healthy_strings_are_untouched() {
+		$healthy = array(
+			'use our %1$sdocs%2$s or log a %3$sticket%4$s.',
+			'at least %s years of age.',
+			'paragraph %d of %d',
+			'padded %1$04d and %2$-10s',
+			'100%% guaranteed',
+			'a sentence with no placeholders at all',
+			'a price of $10 and 50% off',
+		);
+
+		foreach ( $healthy as $string ) {
+			$this->assertSame( $string, cmplz_tc_repair_placeholders( $string ) );
+		}
+	}
+
+	/**
+	 * Repaired placeholders make the damaged translation formattable again.
+	 *
+	 * @return void
+	 */
+	public function test_repaired_string_formats_without_error() {
+		$damaged  = 'Zašlete nám prosím %1$sžádost%2$.';
+		$repaired = cmplz_tc_repair_placeholders( $damaged );
+
+		$this->assertSame( 'Zašlete nám prosím <a>žádost</a>.', sprintf( $repaired, '<a>', '</a>' ) );
+	}
+
+	/**
+	 * End-to-end through __(): the reported fatal no longer happens.
+	 *
+	 * Without the filter this call throws ValueError on PHP 8, which is what took
+	 * Czech sites down on every request.
+	 *
+	 * @return void
+	 */
+	public function test_damaged_translation_does_not_fatal_via_gettext() {
+		$callback = $this->fake_translation(
+			'please read this',
+			'Další informace najdete v tomto %1$článku%2$.'
+		);
+
+		$result = cmplz_tc_read_more( 'https://complianz.io/docs' );
+		remove_filter( 'gettext', $callback, 5 );
+
+		$this->assertStringContainsString( 'href="https://complianz.io/docs"', $result );
+		$this->assertStringContainsString( '>článku</a>', $result );
+		$this->assertStringNotContainsString( '$', $result );
+	}
+
+	/**
+	 * End-to-end through _x(): the document strings are repaired too.
+	 *
+	 * @return void
+	 */
+	public function test_damaged_translation_does_not_fatal_via_gettext_with_context() {
+		$callback = $this->fake_translation(
+			'constitute the entire agreement',
+			'Tyto podmínky spolu s %1$prohlášením%2$ a %3$zásadami%4$ mezi vámi a %5$ ohledně.',
+			'gettext_with_context'
+		);
+
+		$result = sprintf(
+			// translators: 1-4 are anchor tags, 5 is the organisation name.
+			_x( 'These Terms and Conditions, together with our %1$sprivacy statement%2$s and %3$scookie policy%4$s, constitute the entire agreement between you and %5$s in relation to your use of this website.', 'Legal document', 'complianz-terms-conditions' ),
+			'<a>',
+			'</a>',
+			'<a>',
+			'</a>',
+			'Acme BV'
+		);
+		remove_filter( 'gettext_with_context', $callback, 5 );
+
+		$this->assertStringContainsString( '<a>prohlášením</a>', $result );
+		$this->assertStringContainsString( '<a>zásadami</a>', $result );
+		$this->assertStringContainsString( 'a Acme BV ohledně.', $result );
+	}
+
+	/**
+	 * Translations belonging to other plugins are left alone.
+	 *
+	 * @return void
+	 */
+	public function test_other_text_domains_are_not_touched() {
+		$damaged = 'someone else %1$poškozeno%2$.';
+
+		$this->assertSame( $damaged, cmplz_tc_repair_translation( $damaged, 'original', 'other-plugin' ) );
+		$this->assertSame( $damaged, cmplz_tc_repair_translation_with_context( $damaged, 'original', 'Context', 'other-plugin' ) );
+		$this->assertSame(
+			'someone else %1$spoškozeno%2$s.',
+			cmplz_tc_repair_translation( $damaged, 'original', 'complianz-terms-conditions' )
+		);
+	}
+
+	/**
+	 * The filters are registered, so every translated string passes through them.
+	 *
+	 * @return void
+	 */
+	public function test_filters_are_registered() {
+		$this->assertSame( 10, has_filter( 'gettext', 'cmplz_tc_repair_translation' ) );
+		$this->assertSame( 10, has_filter( 'gettext_with_context', 'cmplz_tc_repair_translation_with_context' ) );
+	}
+}


### PR DESCRIPTION
## Complianz l Terms & Conditions plugin throws Fatal Error due to translations

  ### Description
  Repairs damaged printf placeholders in this plugin's translations before any caller formats them, so a malformed community translation can no longer crash the site.

  ### Problem
  The cs_CZ translations on translate.wordpress.org dropped the `s` from several `%N$s` placeholders (`%4$s` typed as `%4$`, `%1$sprivacy` as `%1$privacy`). PHP 8 throws `ValueError: Missing format specifier at end of string` for those patterns. Since the wizard steps and document definitions are built on `init`, the first damaged string fataled every request on Czech sites — frontend and admin — reported three times (2 Freshdesk tickets, 1 wordpress.org thread).

  ### Acceptance Criteria
  - The plugin loads normally in all languages, including Czech.
  - Damaged placeholders no longer raise a fatal error on PHP 8.
  - Locales with valid translations render exactly as before.
  - Other plugins' translations are untouched.

  ### Proposed Solution
  **Placeholder repair**
  - `cmplz_tc_repair_placeholders()` in `functions.php` rewrites `%N$` to `%N$s` when what follows cannot complete a conversion specification.
  - Returns early on strings without `$`, so the cost is one `strpos` per translated string.

  **Filter registration**
  - `cmplz_tc_repair_translation()` and `cmplz_tc_repair_translation_with_context()` filter `gettext` and `gettext_with_context` at priority 10, registered in `hooks()`.
  - Both bail unless the text domain is `complianz-terms-conditions`; no call site is modified, so `sprintf( __() )` in existing and future code is covered, including `class-withdrawal.php`.

  **Tests**
  - `tests/test-format-guard.php`: all five reported cs_CZ strings, healthy patterns left untouched, other text domains untouched, filter registration.
- `tests/test-format-guard.php`: all five reported cs_CZ strings, healthy patterns left untouched, other text domains untouched, filter registration.
- Two end-to-end cases inject a damaged translation through `__()` and `_x()`; both throw `ValueError` when the filters are removed.

### Testing Notes
- `vendor/bin/phpunit`: 167 tests, 397 assertions green (7 new plus the existing 1.4.0 suite, which exercises the filter on every translated string it touches).
- PHPStan level 5, security sniffs, PHP 7.4–8.4 compatibility and phpcs WordPress on the changed files: all clean.
- Verified manually on a site forced to `cs_CZ` with the damaged wordpress.org language pack installed: fatal on `master`, pages render on this branch, Czech wizard intro and T&C document paragraphs keep their links.
- All 40 published locales were linted; cs_CZ was the only one that would throw. The five upstream strings were also corrected on translate.wordpress.org — they are currently waiting for approval.

### Conclusion
A malformed placeholder in any locale now degrades to a slightly odd sentence instead of taking the site down.